### PR TITLE
🔧 fix(analysis-counter.tsx): update limitDesc

### DIFF
--- a/src/features/syntax-analyzer/components/analysis-form/analysis-counter.tsx
+++ b/src/features/syntax-analyzer/components/analysis-form/analysis-counter.tsx
@@ -12,6 +12,7 @@ import {
 import { PropsWithChildren } from 'react';
 import {
   DAILY_ANALYSIS_LIMIT,
+  GPT_4_DECREMENT_COUNT,
   useRemainingCountQuery,
 } from '@/features/syntax-analyzer';
 import { CenteredDivider } from '@/base';
@@ -23,7 +24,7 @@ export default function AnalysisCounter({ ...stackProps }: StackProps) {
   });
 
   const countTitle = `남은 분석 횟수 ${count}회`;
-  const limitDesc = `하루 최대 ${DAILY_ANALYSIS_LIMIT}회까지 분석할 수 있어요 (GPT-4 모델은 요청당 3회 차감)`;
+  const limitDesc = `하루 최대 ${DAILY_ANALYSIS_LIMIT}회까지 분석할 수 있어요 (GPT-4 모델은 요청당 ${GPT_4_DECREMENT_COUNT}회 차감)`;
 
   return (
     <AnalysisCounterBox {...stackProps}>

--- a/src/features/syntax-analyzer/components/analysis-form/model-choice-group.tsx
+++ b/src/features/syntax-analyzer/components/analysis-form/model-choice-group.tsx
@@ -6,22 +6,26 @@ import {
   Stack,
   Text,
 } from '@chakra-ui/react';
-import { AnalysisFormValues } from '@/features/syntax-analyzer';
+import {
+  AnalysisFormValues,
+  GPT_3_DECREMENT_COUNT,
+  GPT_4_DECREMENT_COUNT,
+} from '@/features/syntax-analyzer';
 import { Control, Controller } from 'react-hook-form';
 
 const MODEL_FIELDS = [
   {
-    value: 'gpt-4',
-    label: 'gpt-4',
-    desc: '분석 속도는 느리지만 정확도는 높아요',
-    count: 3,
+    value: 'gpt-3.5-turbo',
+    label: 'GPT-3.5 (Fine-tuned)',
+    desc: '정확도는 GPT 4와 비슷하거나 다소 낮지만 속도가 빨라요',
+    count: GPT_3_DECREMENT_COUNT,
     recommend: true,
   },
   {
-    value: 'gpt-3.5-turbo',
-    label: 'gpt-3.5',
-    desc: '분석 속도는 빠르지만 정확도는 낮아요',
-    count: 1,
+    value: 'gpt-4',
+    label: 'GPT-4',
+    desc: '정확도는 높지만 속도가 느려요',
+    count: GPT_4_DECREMENT_COUNT,
     recommend: false,
   },
 ];
@@ -55,9 +59,7 @@ export default function ModelChoiceGroup({
                   value={field.value}
                   isDisabled={remainingCount < field.count}
                 >
-                  <Text as="span" textTransform="uppercase">
-                    {field.label}
-                  </Text>
+                  <Text as="span">{field.label}</Text>
                 </Radio>
                 <Badge
                   fontSize={10}

--- a/src/features/syntax-analyzer/constants/settings.ts
+++ b/src/features/syntax-analyzer/constants/settings.ts
@@ -1,5 +1,8 @@
 export const DAILY_ANALYSIS_LIMIT = 10;
 
+export const GPT_4_DECREMENT_COUNT = 5;
+export const GPT_3_DECREMENT_COUNT = 1;
+
 export const MAX_TOPIC_ADDITION = 3;
 export const DAILY_SENTENCE_LIMIT = 20;
 

--- a/src/features/syntax-analyzer/hooks/use-analysis-form.ts
+++ b/src/features/syntax-analyzer/hooks/use-analysis-form.ts
@@ -12,7 +12,6 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { getSyntaxEditorPath } from '@/routes';
 import { expandAbbreviations, tokenizer } from '@/base';
 import { useDisclosure, useToast, UseToastOptions } from '@chakra-ui/react';
-import { useEffect } from 'react';
 import { updateAnalysisMetaData } from '@/features/syntax-editor';
 
 export type AnalysisModel = 'gpt-3.5-turbo' | 'gpt-4';
@@ -45,6 +44,7 @@ export const useAnalysisForm = () => {
 
   const formResults = useForm<AnalysisFormValues>({
     resolver: yupResolver(createAnalysisFormSchema),
+    defaultValues: createAnalysisFormSchema.cast({}),
   });
 
   const mutationResults = useCreateAnalysisMutation({
@@ -59,12 +59,8 @@ export const useAnalysisForm = () => {
     meta: { invalidateQueries: REMAINING_COUNT_BASE_KEY },
   });
 
-  const { getValues, handleSubmit, reset } = formResults;
+  const { getValues, handleSubmit } = formResults;
   const { mutate } = mutationResults;
-
-  useEffect(() => {
-    reset(getDefaultValues(remainingCount));
-  }, [remainingCount, reset]);
 
   const onSubmitConfirm = () => {
     const { model, sentence } = getValues();
@@ -85,8 +81,3 @@ export const useAnalysisForm = () => {
     ...mutationResults,
   };
 };
-
-const getDefaultValues = (count: number): AnalysisFormValues => ({
-  sentence: '',
-  model: count > 2 ? 'gpt-4' : 'gpt-3.5-turbo',
-});

--- a/src/features/syntax-analyzer/schemes/analysis-form-schema.ts
+++ b/src/features/syntax-analyzer/schemes/analysis-form-schema.ts
@@ -10,6 +10,6 @@ export const createAnalysisFormSchema = yup.object({
   model: yup
     .mixed<AnalysisModel>()
     .oneOf(['gpt-3.5-turbo', 'gpt-4'])
-    .required(),
-  sentence: englishSentenceSchema.required(),
+    .default('gpt-3.5-turbo'),
+  sentence: englishSentenceSchema.ensure(),
 });


### PR DESCRIPTION
🔧 fix(model-choice-group.tsx): update count values for GPT-3.5 and GPT-4 models to use GPT_3_DECREMENT_COUNT and GPT_4_DECREMENT_COUNT variables
🔧 fix(settings.ts): update GPT_4_DECREMENT_COUNT and GPT_3_DECREMENT_COUNT values to reflect correct decrement counts
🔧 fix(use-analysis-form.ts): remove unused reset function and set defaultValues using createAnalysisFormSchema.cast({})
🔧 fix(analysis-form-schema.ts): set default value for model field to 'gpt-3.5-turbo' and ensure sentence field is not empty