### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -8,6 +8,9 @@ on:
 #    branches:
 #      - main
 
+permissions:
+  contents: read
+
 jobs:
   qodana:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/romantech/syntax-analyzer/security/code-scanning/1](https://github.com/romantech/syntax-analyzer/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow. This block will explicitly define the minimal permissions required for the workflow to function. Since the workflow primarily performs a Qodana scan, it likely only needs `contents: read` permission. This change will ensure that the `GITHUB_TOKEN` is restricted to read-only access to repository contents, reducing the risk of unintended modifications.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
