### PR TITLE
[codex] add pnpm minimum release age

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "type": "module",
+  "packageManager": "pnpm@10.16.0",
   "author": "Romantech",
   "license": "MIT",
   "description": "Visual tool for English syntax analysis",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 10080

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,4 @@
+packages:
+  - '.'
+
 minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

- Add `pnpm-workspace.yaml` with `minimumReleaseAge: 10080`.
- Configure pnpm to wait seven days before installing newly released package versions.

## Impact

This reduces exposure to newly published compromised package versions while keeping the existing dependency setup unchanged.

## Validation

- `pnpm config get minimumReleaseAge` returned `10080`.
- Commit hook completed; lint-staged found no matching staged files.