### PR TITLE
fix(deps): resolve React Router alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-error-boundary": "^4.1.2",
     "react-hook-form": "^7.83.0",
     "react-icons": "^5.7.0",
-    "react-router-dom": "^6.30.4",
+    "react-router": "^8.3.0",
     "sass": "^1.102.0",
     "yup": "^1.7.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  brace-expansion@>=2.0.0 <2.1.3: 2.1.3
   esbuild: 0.28.1
   form-data: 4.0.6
   jsondiffpatch: 0.7.3
@@ -90,9 +91,9 @@ importers:
       react-icons:
         specifier: ^5.7.0
         version: 5.7.0(react@19.2.8)
-      react-router-dom:
-        specifier: ^6.30.4
-        version: 6.30.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-router:
+        specifier: ^8.3.0
+        version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       sass:
         specifier: ^1.102.0
         version: 1.102.0
@@ -1157,10 +1158,6 @@ packages:
     peerDependencies:
       redux: ^3.1.0 || ^4.0.0 || ^5.0.0
 
-  '@remix-run/router@1.23.3':
-    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
-    engines: {node: '>=14.0.0'}
-
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
@@ -1641,8 +1638,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.3:
+    resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -1740,6 +1737,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
@@ -2599,18 +2599,15 @@ packages:
       react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
-  react-router-dom@6.30.4:
-    resolution: {integrity: sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==}
-    engines: {node: '>=14.0.0'}
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
+    engines: {node: '>=22.22.0'}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
-  react-router@6.30.4:
-    resolution: {integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-simple-animate@3.5.3:
     resolution: {integrity: sha512-Ob+SmB5J1tXDEZyOe2Hf950K4M8VaWBBmQ3cS2BUnTORqHjhK0iKG8fB+bo47ZL15t8d3g/Y0roiqH05UBjG7A==}
@@ -4336,8 +4333,6 @@ snapshots:
       immutable: 4.3.9
       redux: 5.0.1
 
-  '@remix-run/router@1.23.3': {}
-
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2)':
@@ -4735,7 +4730,7 @@ snapshots:
 
   baseline-browser-mapping@2.11.3: {}
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.3:
     dependencies:
       balanced-match: 1.0.2
 
@@ -4834,6 +4829,8 @@ snapshots:
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie-es@3.1.1: {}
 
   copy-to-clipboard@3.3.3:
     dependencies:
@@ -5527,7 +5524,7 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.3
 
   minipass@7.1.3: {}
 
@@ -5728,17 +5725,12 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  react-router-dom@6.30.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      '@remix-run/router': 1.23.3
+      cookie-es: 3.1.1
       react: 19.2.8
+    optionalDependencies:
       react-dom: 19.2.8(react@19.2.8)
-      react-router: 6.30.4(react@19.2.8)
-
-  react-router@6.30.4(react@19.2.8):
-    dependencies:
-      '@remix-run/router': 1.23.3
-      react: 19.2.8
 
   react-simple-animate@3.5.3(react-dom@19.2.8(react@19.2.8)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
 minimumReleaseAge: 10080
 
 overrides:
+  'brace-expansion@>=2.0.0 <2.1.3': 2.1.3
   esbuild: 0.28.1
   form-data: 4.0.6
   jsondiffpatch: 0.7.3

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,7 +2,7 @@ import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 import { LazyMotion } from 'framer-motion';
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 
 import { Layout, ThreeDotsWave, useRemoveBodyBgColor } from '@/base';
 import { ErrorComponent } from '@/features/misc';

--- a/src/base/components/layout/header.tsx
+++ b/src/base/components/layout/header.tsx
@@ -14,7 +14,7 @@ import {
 import { BsGithub } from 'react-icons/bs';
 import { FiCoffee } from 'react-icons/fi';
 import { MdModeNight, MdOutlineLightMode } from 'react-icons/md';
-import { matchPath, NavLink, useLocation } from 'react-router-dom';
+import { matchPath, NavLink, useLocation } from 'react-router';
 
 import { SITE_URLS } from '@/routes/paths';
 

--- a/src/features/misc/components/showcase/showcase-template.tsx
+++ b/src/features/misc/components/showcase/showcase-template.tsx
@@ -1,6 +1,6 @@
 import { Flex, type FlexProps, Heading, HStack, Link, Stack, Text } from '@chakra-ui/react';
 import type { FunctionComponent } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 
 import { LazyImage, type LazyImageProps } from '@/base';
 import ScrollDownButton from './scroll-down-button';

--- a/src/features/misc/pages/error-component.tsx
+++ b/src/features/misc/pages/error-component.tsx
@@ -9,7 +9,7 @@ import {
   VStack,
 } from '@chakra-ui/react';
 import type { FallbackProps } from 'react-error-boundary';
-import { isRouteErrorResponse, Navigate, useRouteError } from 'react-router-dom';
+import { isRouteErrorResponse, Navigate, useRouteError } from 'react-router';
 
 import { DIGITS_PATTERN, Layout, LinkParticles, useIsMounted } from '@/base';
 

--- a/src/features/syntax-analyzer/hooks/use-analysis-form.ts
+++ b/src/features/syntax-analyzer/hooks/use-analysis-form.ts
@@ -1,7 +1,7 @@
 import { type UseToastOptions, useDisclosure, useToast } from '@chakra-ui/react';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { ensurePeriod, expandAbbreviations, removeThousandSeparator, tokenizer } from '@/base';
 import {

--- a/src/features/syntax-editor/components/control-panel/save-button.tsx
+++ b/src/features/syntax-editor/components/control-panel/save-button.tsx
@@ -2,7 +2,7 @@ import { IconButton, Tooltip, useToast } from '@chakra-ui/react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useState } from 'react';
 import { IoSaveSharp } from 'react-icons/io5';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { ConfirmPopover } from '@/base';
 import {

--- a/src/features/syntax-editor/components/sentence-manager/sentence-list.tsx
+++ b/src/features/syntax-editor/components/sentence-manager/sentence-list.tsx
@@ -14,7 +14,7 @@ import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { Fragment, useRef } from 'react';
 import { TbMoodEmpty } from 'react-icons/tb';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import {
   analysisListBySourceAtom,
   removeUserAnalysisActionAtom,

--- a/src/features/syntax-editor/hooks/use-analysis-data-loader.ts
+++ b/src/features/syntax-editor/hooks/use-analysis-data-loader.ts
@@ -1,6 +1,6 @@
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect, useRef } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import {
   type AnalysisPathParams,

--- a/src/features/syntax-editor/pages/syntax-editor-root.tsx
+++ b/src/features/syntax-editor/pages/syntax-editor-root.tsx
@@ -1,5 +1,5 @@
 import { Provider } from 'jotai';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 
 import { JotaiDevTools, Layout } from '@/base';
 import { analysisStore } from '@/features/syntax-editor';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/react';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { RouterProvider } from 'react-router-dom';
+import { RouterProvider } from 'react-router';
 
 import '@/lib/configure-dotlottie';
 import { ConfiguredQueryProvider } from '@/lib';
@@ -25,13 +25,7 @@ createRoot(rootElement).render(
       <ColorModeScript initialColorMode={theme.config.initialColorMode} />
       <ConfiguredQueryProvider>
         <ReactQueryDevtools initialIsOpen={false} position="bottom" />
-        <RouterProvider
-          router={router}
-          future={{
-            /** @see https://reactrouter.com/en/6.28.2/upgrading/future#v7_starttransition */
-            v7_startTransition: true,
-          }}
-        />
+        <RouterProvider router={router} />
       </ConfiguredQueryProvider>
     </ChakraProvider>
   </StrictMode>,

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from 'react-router-dom';
+import { createBrowserRouter } from 'react-router';
 
 import { lazyImport } from '@/base';
 
@@ -14,42 +14,34 @@ const { SentenceManager, SyntaxEditor, SyntaxEditorRoot } = lazyImport(
   () => import('@/features/syntax-editor'),
 );
 
-export const router = createBrowserRouter(
-  [
-    {
-      path: SITE_URLS.ROOT,
-      element: <App />,
-      errorElement: <ErrorComponent />,
-      children: [
-        {
-          index: true,
-          element: <Home />,
-        },
-        {
-          path: SITE_URLS.ANALYZER.ROOT,
-          element: <SyntaxAnalyzer />,
-        },
-        {
-          path: SITE_URLS.EDITOR.ROOT,
-          element: <SyntaxEditorRoot />,
-          children: [
-            {
-              index: true,
-              element: <SentenceManager />,
-            },
-            {
-              path: SITE_URLS.EDITOR.EDIT,
-              element: <SyntaxEditor />,
-            },
-          ],
-        },
-      ],
-    },
-  ],
+export const router = createBrowserRouter([
   {
-    future: {
-      /** @see https://reactrouter.com/en/6.28.2/upgrading/future#v7_relativesplatpath */
-      v7_relativeSplatPath: true,
-    },
+    path: SITE_URLS.ROOT,
+    element: <App />,
+    errorElement: <ErrorComponent />,
+    children: [
+      {
+        index: true,
+        element: <Home />,
+      },
+      {
+        path: SITE_URLS.ANALYZER.ROOT,
+        element: <SyntaxAnalyzer />,
+      },
+      {
+        path: SITE_URLS.EDITOR.ROOT,
+        element: <SyntaxEditorRoot />,
+        children: [
+          {
+            index: true,
+            element: <SentenceManager />,
+          },
+          {
+            path: SITE_URLS.EDITOR.EDIT,
+            element: <SyntaxEditor />,
+          },
+        ],
+      },
+    ],
   },
-);
+]);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ const manualChunks = (id: string): string | undefined => {
 
   // 1. 코어 라이브러리 (React 생태계)
   if (inPkg('react') || inPkg('react-dom') || inPkg('scheduler')) return 'react';
-  if (inPkg('react-router') || inPkg('react-router-dom')) return 'router';
+  if (inPkg('react-router')) return 'router';
 
   // 2. UI 및 스타일링 (Chakra UI는 Emotion을 강하게 의존)
   if (inPkg('@chakra-ui') || inPkg('@emotion')) return 'chakra';


### PR DESCRIPTION
## Summary

- replace `react-router-dom` 6.30.4 with `react-router` 8.3.0
- migrate imports and remove obsolete v7 future flags
- constrain the `brace-expansion` security override to vulnerable 2.x releases

## Why

Dependabot alerts #96–#98 affect the current React Router dependency. The initially patched v7 line also has a newer high-severity RSC advisory, so this moves directly to the safe v8 release instead of introducing another vulnerable version.

## Impact

Routing behavior stays the same. The dependency now requires Node.js 22.22.0 or newer.

## Validation

- `pnpm run build`
- `pnpm run lint`
- `pnpm audit --prod=false` — no known vulnerabilities