### PR TITLE
fix: declare minimum Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "1.0.0",
   "type": "module",
   "packageManager": "pnpm@10.16.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "author": "Romantech",
   "license": "MIT",
   "description": "Visual tool for English syntax analysis",


### PR DESCRIPTION
## Summary

- declare Node.js 22.22.0 as the project minimum in `package.json`

## Why

React Router 8.3.0 requires Node.js 22.22.0 or newer, but the project manifest did not expose that requirement. Unsupported development or deployment environments could therefore proceed until install or build time.

## Impact

Tooling can select a compatible Node.js runtime before installing dependencies. This addresses both unresolved review threads on #96.

## Validation

- `pnpm run lint`
- `pnpm run build`
- `git diff --check`